### PR TITLE
Update class-view-addons.php

### DIFF
--- a/admin/views/class-view-addons.php
+++ b/admin/views/class-view-addons.php
@@ -123,7 +123,7 @@ class View_Addons extends View {
 							<?php if ( file_exists( members_plugin()->dir . "img/{$addon->name}.svg" ) ) : ?>
 
 								<span class="plugin-icon members-svg-link">
-									<?php include members_plugin()->dir . "img/{$addon->name}.svg"; ?>
+									<?php echo file_get_contents(members_plugin()->dir . "img/{$addon->name}.svg"); ?>
 								</span>
 
 							<?php elseif ( $addon->icon_url ) : ?>


### PR DESCRIPTION
Get the contents of SVGs rather than loading them as PHP files, which results in a parsing error:
https://github.com/caseproof/members/issues/3