### PR TITLE
 Block permissions: Avoid PHP notice if innerBlocks is not set

### DIFF
--- a/addons/members-block-permissions/src/Block.php
+++ b/addons/members-block-permissions/src/Block.php
@@ -47,7 +47,7 @@ class Block {
 	public function renderBlock( $content, $block ) {
 
 		// Check if we have nested blocks (e.g. columns)
-		if ( is_array( $block['innerBlocks'] ) && ! empty( $block['innerBlocks'] ) ) {
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
 			foreach ( $block['innerBlocks'] as $inner_block ) {
 				$this->renderBlock( $content, $inner_block );
 			}


### PR DESCRIPTION
This switches the two conditions to avoid a PHP notice: "Undefined index: innerBlocks".