### PR TITLE
Fix hierarchical roles missing settings

### DIFF
--- a/addons/members-role-hierarchy/admin/functions-settings.php
+++ b/addons/members-role-hierarchy/admin/functions-settings.php
@@ -30,7 +30,7 @@ function mrh_register_settings() {
 		'mrh_role_hierarchy',
 		esc_html__( 'Role Hierarchy', 'members' ),
 		'mrh_settings_field_hierarchy',
-		'admin_page_members-settings',
+		'members-settings',
 		'roles_caps'
 	);
 }


### PR DESCRIPTION
Updated setting field to display Hierarchical roles no “lower” / “equal or lower” option.

Implemented the fix in this post
https://wordpress.org/support/topic/hierarchical-roles-no-longer-have-lower-equal-or-lower-option/