### PR TITLE
Allow the minimum 'view in admin' role of 'list_roles' to be filtered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/admin/class-manage-roles.php
+++ b/admin/class-manage-roles.php
@@ -73,7 +73,7 @@ final class Manage_Roles {
 
 		// The "Roles" page should be shown for anyone that has the 'list_roles', 'edit_roles', or
 		// 'delete_roles' caps, so we're checking against all three.
-		$edit_roles_cap = apply_filters( 'members_min_show_admin_role', 'list_roles' );
+		$edit_roles_cap = apply_filters( 'members_show_roles_page_cap ', 'list_roles' );
 
 
 		// If the current user can 'edit_roles'.

--- a/admin/class-manage-roles.php
+++ b/admin/class-manage-roles.php
@@ -73,7 +73,8 @@ final class Manage_Roles {
 
 		// The "Roles" page should be shown for anyone that has the 'list_roles', 'edit_roles', or
 		// 'delete_roles' caps, so we're checking against all three.
-		$edit_roles_cap = 'list_roles';
+		$edit_roles_cap = apply_filters( 'members_min_show_admin_role', 'list_roles' );
+
 
 		// If the current user can 'edit_roles'.
 		if ( current_user_can( 'edit_roles' ) )


### PR DESCRIPTION
Just because a user can list_roles does not mean they need to have the Members menu item added to their admin. For example, if we want to allow a manager to promote an employee to become a manager they need the ability to list_roles but do not need to have the Members menu added to their admin interface.

usage:

```
// Only show members manager in admin to admins.
add_filter( 'members_min_show_admin_role', 'show_role_manager' );
function show_role_manager( $edit_roles_cap ){
	return 'edit_roles';
}
```