### PR TITLE
Add filter to WP roles in Content Permissions box

### DIFF
--- a/admin/class-meta-box-content-permissions.php
+++ b/admin/class-meta-box-content-permissions.php
@@ -161,7 +161,7 @@ final class Meta_Box_Content_Permissions {
 		global $wp_roles;
 
 		// Get roles and sort.
-		 $_wp_roles = $wp_roles->role_names;
+		 $_wp_roles = apply_filters( 'members_wp_roles', $wp_roles->role_names, $post );
 		asort( $_wp_roles );
 
 		// Get the roles saved for the post.


### PR DESCRIPTION
It's a user request. It might be useful to limit user roles and display a subset of the roles in the Content Permissions box.