### PR TITLE
Fix PHP 8.1 deprecation notice.

### DIFF
--- a/addons/members-acf-integration/src/Plugin.php
+++ b/addons/members-acf-integration/src/Plugin.php
@@ -243,7 +243,7 @@ class Plugin {
 
 			// Adds support for an author field so that the `*_others_*`
 			// caps actually have some meaning.
-			if ( is_array( $args['support'] ) ) {
+			if ( is_array( $args['supports'] ) ) {
 				$args['supports'][] = 'author';
 			} else {
 				$args['supports'] = array( 'author' );

--- a/addons/members-acf-integration/src/Plugin.php
+++ b/addons/members-acf-integration/src/Plugin.php
@@ -243,7 +243,11 @@ class Plugin {
 
 			// Adds support for an author field so that the `*_others_*`
 			// caps actually have some meaning.
-			$args['supports'][] = 'author';
+			if ( is_array( $args['support'] ) ) {
+				$args['supports'][] = 'author';
+			} else {
+				$args['supports'] = array( 'author' );
+			}
 
 			// Change the capability type to tie it to the CPT.
 			$args['capability_type'] = 'acf_field_group';


### PR DESCRIPTION
Starting in PHP 8.1, the process of auto-creating arrays from "false" values is deprecated so we'll want to ensure we're working with an actual array before assigning elements to it: https://wiki.php.net/rfc/autovivification_false