### PR TITLE
Fix PHP warning for undefined global variable $wp_embed

### DIFF
--- a/inc/functions-private-site.php
+++ b/inc/functions-private-site.php
@@ -21,8 +21,10 @@ add_filter( 'the_excerpt_rss',  'members_private_feed', 95 );
 add_filter( 'comment_text_rss', 'members_private_feed', 95 );
 
 # Filters for the feed error message.
-add_filter( 'members_feed_error_message', array( $GLOBALS['wp_embed'], 'run_shortcode' ),   5 );
-add_filter( 'members_feed_error_message', array( $GLOBALS['wp_embed'], 'autoembed'     ),   5 );
+if ( isset( $GLOBALS['wp_embed'] ) && $GLOBALS['wp_embed'] instanceof \WP_Embed ) {
+	add_filter( 'members_feed_error_message', array( $GLOBALS['wp_embed'], 'run_shortcode' ),   5 );
+	add_filter( 'members_feed_error_message', array( $GLOBALS['wp_embed'], 'autoembed'     ),   5 );
+}
 add_filter( 'members_feed_error_message',                              'wptexturize',       10 );
 add_filter( 'members_feed_error_message',                              'convert_smilies',   15 );
 add_filter( 'members_feed_error_message',                              'convert_chars',     20 );


### PR DESCRIPTION
I started noticing the following PHP warning in the logs and again in reports when running static analysis. 

`PHP Warning:  Undefined global variable $wp_embed in members\inc\functions-private-site.php on line 25`

This warning is easily fixed by checking for the existence of type of the global variable before using it.