### PR TITLE
Fix translation notices in WP 6.7

### DIFF
--- a/addons/members-acf-integration/src/Plugin.php
+++ b/addons/members-acf-integration/src/Plugin.php
@@ -47,7 +47,7 @@ class Plugin {
 		}
 
 		// Load translations.
-		add_action( 'plugins_loaded', [ $this, 'loadTextdomain' ] );
+		add_action( 'after_setup_theme', [ $this, 'loadTextdomain' ] );
 
 		// Filter the ACF settings capability.
 		add_filter( 'acf/settings/capability', [ $this, 'acfSettingsCapability' ] );

--- a/members.php
+++ b/members.php
@@ -269,7 +269,7 @@ final class Members_Plugin {
 	private function setup_actions() {
 
 		// Internationalize the text strings used.
-		add_action( 'plugins_loaded', array( $this, 'i18n' ), 2 );
+		add_action( 'after_setup_theme', array( $this, 'i18n' ), 2 );
 
 		// Migrate add-ons
 		add_action( 'plugins_loaded', array( $this, 'migrate_addons' ) );


### PR DESCRIPTION
Resolves #126 