### PR TITLE
Hide notifications button based on permissions

### DIFF
--- a/admin/class-notifications.php
+++ b/admin/class-notifications.php
@@ -409,6 +409,10 @@ class Notifications {
    */
   public function admin_menu_append_count() {
 
+    if ( ! self::has_access() ) {
+        return;
+    }
+
     $option = get_option( 'members_notifications' );
     $notifications = ! empty( $option['feed'] ) ? $option['feed'] : array();
     $active_notifications = isset( $this->get()['active'] ) ? $this->get()['active'] : array();
@@ -433,14 +437,14 @@ class Notifications {
       <?php
     }
 
-    if ( members_is_admin_page() && $this->has_access() ) {
+    if ( members_is_admin_page() ) {
       ob_start();
 
       ?>
 
       <button id="membersAdminHeaderNotifications" class="members-notifications-button button-secondary">
         <svg width="22" height="14" viewBox="0 0 22 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21.6944 6.5625C21.8981 6.85417 22 7.18229 22 7.54687V12.25C22 12.7361 21.8218 13.1493 21.4653 13.4896C21.1088 13.8299 20.6759 14 20.1667 14H1.83333C1.32407 14 0.891204 13.8299 0.534722 13.4896C0.178241 13.1493 0 12.7361 0 12.25V7.54687C0 7.18229 0.101852 6.85417 0.305556 6.5625L4.35417 0.765625C4.45602 0.644097 4.58333 0.522569 4.73611 0.401042C4.91435 0.279514 5.10532 0.182292 5.30903 0.109375C5.51273 0.0364583 5.7037 0 5.88194 0H16.1181C16.3981 0 16.6782 0.0850694 16.9583 0.255208C17.2639 0.401042 17.4931 0.571181 17.6458 0.765625L21.6944 6.5625ZM6.1875 2.33333L2.94097 7H7.63889L8.86111 9.33333H13.1389L14.3611 7H19.059L15.8125 2.33333H6.1875Z" fill="#2679C1"></path></svg>
-        <?php if ( self::has_access() && ! empty( $notifications ) && count( $notifications ) > 0 ) : ?>
+        <?php if ( ! empty( $notifications ) && count( $notifications ) > 0 ) : ?>
           <span id="membersAdminHeaderNotificationsCount" class="members-notifications-count"><?php echo count( $notifications ); ?></span>
         <?php endif; ?>
       </button>


### PR DESCRIPTION
If you use `add_filter( 'members_admin_notifications_has_access', '__return_false' );` the button next to the heading is still visible and does nothing.

<img width="285" height="122" alt="WordPress admin with notifications button" src="https://github.com/user-attachments/assets/af2876fa-2e67-4a01-9fa4-86c4751058ca" />
