### PR TITLE
Fix trailing space in members_show_roles_page_cap filter name

### DIFF
--- a/admin/class-manage-roles.php
+++ b/admin/class-manage-roles.php
@@ -73,7 +73,7 @@ final class Manage_Roles {
 
 		// The "Roles" page should be shown for anyone that has the 'list_roles', 'edit_roles', or
 		// 'delete_roles' caps, so we're checking against all three.
-		$edit_roles_cap = apply_filters( 'members_show_roles_page_cap ', 'list_roles' );
+		$edit_roles_cap = apply_filters( 'members_show_roles_page_cap', 'list_roles' );
 
 
 		// If the current user can 'edit_roles'.


### PR DESCRIPTION
Hey Justin,

Found a trailing space in the members_show_roles_page_cap filter name on line 76 of class-manage-roles.php — it's registered as 'members_show_roles_page_cap ' (space before the closing quote). WordPress does an exact string match on filter names, so any plugin or theme hooking the correctly-spelled name would never fire. One character removal.

(full disclosure, I used AI help with the testing and tweaks - Christopher)