### PR TITLE
Fix unauthenticated REST API pagination side channel (CVE-2026-12426)

### DIFF
--- a/inc/functions-content-permissions.php
+++ b/inc/functions-content-permissions.php
@@ -567,6 +567,297 @@ function members_filter_protected_posts_for_rest( $posts, $query ) {
 }
 
 /**
+ * Maximum ancestor depth considered when mirroring hierarchical permissions in SQL.
+ *
+ * @since 3.2.23
+ * @access private
+ * @var int
+ */
+$GLOBALS['members_rest_protected_posts_ancestor_depth'] = 15;
+
+/**
+ * Whether the REST protected-post SQL exclusion should run for a query.
+ *
+ * Only paginated collection queries expose X-WP-Total / X-WP-TotalPages headers.
+ * Single-item lookups and unbounded queries are skipped to avoid unnecessary work.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  WP_Query  $query  The WP_Query object.
+ * @return bool
+ */
+function members_should_apply_rest_protected_posts_sql( $query ) {
+
+	if ( ! $query instanceof \WP_Query ) {
+		return false;
+	}
+
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		return false;
+	}
+
+	// Single-item lookups do not expose collection pagination headers.
+	if ( $query->get( 'p' ) || $query->get( 'page_id' ) || $query->get( 'name' ) || $query->get( 'pagename' ) ) {
+		return false;
+	}
+
+	$per_page = (int) $query->get( 'posts_per_page' );
+
+	return $per_page > 0;
+}
+
+/**
+ * Returns a SQL expression for the post ID at a given ancestor depth.
+ *
+ * Depth 0 is the current row, depth 1 is post_parent, and so on.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  int  $depth  Ancestor depth.
+ * @return string
+ */
+function members_sql_post_id_at_depth( $depth ) {
+
+	global $wpdb;
+
+	if ( 0 === $depth ) {
+		return "{$wpdb->posts}.ID";
+	}
+
+	$id = "{$wpdb->posts}.post_parent";
+
+	for ( $i = 2; $i <= $depth; $i++ ) {
+		$id = "(SELECT p_depth_{$i}.post_parent FROM {$wpdb->posts} p_depth_{$i} WHERE p_depth_{$i}.ID = {$id} LIMIT 1)";
+	}
+
+	return $id;
+}
+
+/**
+ * Returns SQL that is true when a post has content-permission role meta.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  string  $post_id_sql  SQL expression for a post ID column.
+ * @return string
+ */
+function members_sql_post_has_access_role_meta( $post_id_sql ) {
+
+	global $wpdb;
+
+	return "EXISTS (
+		SELECT 1 FROM {$wpdb->postmeta} pm_roles
+		WHERE pm_roles.post_id = {$post_id_sql}
+		AND pm_roles.meta_key IN ( '_members_access_role', '_role' )
+	)";
+}
+
+/**
+ * Returns SQL that is true when a restricted post is viewable for the given roles.
+ *
+ * Mirrors the role, post-author, and ancestor-author checks from members_can_user_view_post().
+ * Does not cover edit_post / restrict_content bypasses; those are applied separately.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  string  $post_id_sql  SQL expression for a post ID column.
+ * @param  array   $roles        Current user role slugs.
+ * @param  int     $user_id      Current user ID.
+ * @return string
+ */
+function members_sql_post_access_roles_satisfied( $post_id_sql, $roles, $user_id ) {
+
+	global $wpdb;
+
+	$parts = array();
+
+	if ( ! empty( $roles ) ) {
+		$placeholders = implode( ', ', array_fill( 0, count( $roles ), '%s' ) );
+
+		// WordPress $wpdb->prepare() accepts a roles array when placeholder count matches.
+		$parts[] = $wpdb->prepare(
+			"EXISTS (
+				SELECT 1 FROM {$wpdb->postmeta} pm_allow
+				WHERE pm_allow.post_id = {$post_id_sql}
+				AND pm_allow.meta_key IN ( '_members_access_role', '_role' )
+				AND pm_allow.meta_value IN ( {$placeholders} )
+			)",
+			$roles
+		);
+	}
+
+	if ( $user_id ) {
+		$parts[] = $wpdb->prepare(
+			"EXISTS (
+				SELECT 1 FROM {$wpdb->posts} p_author
+				WHERE p_author.ID = {$post_id_sql}
+				AND p_author.post_author = %d
+			)",
+			$user_id
+		);
+	}
+
+	if ( empty( $parts ) ) {
+		return '0=1';
+	}
+
+	return '(' . implode( ' OR ', $parts ) . ')';
+}
+
+/**
+ * Returns SQL that is true when any ancestor carries content-permission role meta.
+ *
+ * Used for logged-out users where no role can satisfy a restriction.
+ *
+ * @since 3.2.23
+ * @access public
+ * @return string
+ */
+function members_sql_any_ancestor_has_access_role_meta() {
+
+	global $wpdb;
+
+	$depth_limit = (int) $GLOBALS['members_rest_protected_posts_ancestor_depth'];
+	$checks      = array();
+
+	for ( $depth = 1; $depth <= $depth_limit; $depth++ ) {
+		$ancestor_id = members_sql_post_id_at_depth( $depth );
+		$checks[]    = "(
+			{$ancestor_id} > 0
+			AND " . members_sql_post_has_access_role_meta( $ancestor_id ) . '
+		)';
+	}
+
+	return '(' . implode( ' OR ', $checks ) . ')';
+}
+
+/**
+ * Returns SQL that is true when a post inherits an unsatisfied restriction from an ancestor.
+ *
+ * Walks up the parent chain and applies the first ancestor that carries role meta,
+ * matching members_can_user_view_post() hierarchical checks.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  array  $roles    Current user role slugs.
+ * @param  int    $user_id  Current user ID.
+ * @return string
+ */
+function members_sql_inherited_restriction_unsatisfied( $roles, $user_id ) {
+
+	global $wpdb;
+
+	$depth_limit = (int) $GLOBALS['members_rest_protected_posts_ancestor_depth'];
+	$self_id       = "{$wpdb->posts}.ID";
+	$no_self_meta  = 'NOT ' . members_sql_post_has_access_role_meta( $self_id );
+	$cases         = array();
+
+	for ( $depth = 1; $depth <= $depth_limit; $depth++ ) {
+		$ancestor_id = members_sql_post_id_at_depth( $depth );
+		$parts       = array( $no_self_meta );
+
+		for ( $intermediate = 1; $intermediate < $depth; $intermediate++ ) {
+			$parts[] = 'NOT ' . members_sql_post_has_access_role_meta( members_sql_post_id_at_depth( $intermediate ) );
+		}
+
+		$parts[] = "{$ancestor_id} > 0";
+		$parts[] = members_sql_post_has_access_role_meta( $ancestor_id );
+		$parts[] = 'NOT (' . members_sql_post_access_roles_satisfied( $ancestor_id, $roles, $user_id ) . ')';
+
+		$cases[] = '(' . implode( ' AND ', $parts ) . ')';
+	}
+
+	return '(' . implode( ' OR ', $cases ) . ')';
+}
+
+/**
+ * Returns SQL that is true when the current user can edit others' posts of the row type.
+ *
+ * Approximates the edit_post bypass from members_can_user_view_post() for REST collections.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  int  $user_id  Current user ID.
+ * @return string
+ */
+function members_sql_user_can_edit_others_post_types( $user_id ) {
+
+	global $wpdb;
+
+	if ( ! $user_id ) {
+		return '0=1';
+	}
+
+	$parts = array();
+
+	foreach ( get_post_types( array(), 'objects' ) as $post_type ) {
+
+		if ( empty( $post_type->cap->edit_others_posts ) ) {
+			continue;
+		}
+
+		if ( user_can( $user_id, $post_type->cap->edit_others_posts ) ) {
+			$parts[] = $wpdb->prepare( "{$wpdb->posts}.post_type = %s", $post_type->name );
+		}
+	}
+
+	if ( empty( $parts ) ) {
+		return '0=1';
+	}
+
+	return '(' . implode( ' OR ', $parts ) . ')';
+}
+
+/**
+ * Builds the SQL fragment that excludes posts the current user cannot view.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param  array  $roles    Current user role slugs.
+ * @param  int    $user_id  Current user ID.
+ * @return string
+ */
+function members_build_rest_protected_posts_exclusion_sql( $roles, $user_id ) {
+
+	global $wpdb;
+
+	$post_id   = "{$wpdb->posts}.ID";
+	$has_roles = members_sql_post_has_access_role_meta( $post_id );
+
+	if ( empty( $roles ) ) {
+
+		// Logged-out visitors cannot satisfy any role restriction on the post or an ancestor.
+		$restricted = "(
+			{$has_roles}
+			OR (
+				NOT {$has_roles}
+				AND " . members_sql_any_ancestor_has_access_role_meta() . '
+			)
+		)';
+
+		return " AND NOT ({$restricted})";
+	}
+
+	$roles_unsatisfied = 'NOT (' . members_sql_post_access_roles_satisfied( $post_id, $roles, $user_id ) . ')';
+
+	$direct_restricted = "(
+		{$has_roles}
+		AND {$roles_unsatisfied}
+	)";
+
+	$inherited_restricted = members_sql_inherited_restriction_unsatisfied( $roles, $user_id );
+
+	$edit_bypass = members_sql_user_can_edit_others_post_types( $user_id );
+
+	$restricted = "(
+		({$direct_restricted} OR {$inherited_restricted})
+		AND NOT ({$edit_bypass})
+	)";
+
+	return " AND NOT ({$restricted})";
+}
+
+/**
  * Excludes protected posts from REST API queries at the SQL level.
  *
  * Filtering the results after the query runs (see
@@ -576,6 +867,10 @@ function members_filter_protected_posts_for_rest( $posts, $query ) {
  * existence and contents of hidden posts. Excluding the rows in the SQL query
  * itself keeps the counts accurate and closes that side channel.
  *
+ * SQL exclusion mirrors members_can_user_view_post() for direct and inherited
+ * (parent) restrictions, including post-author bypasses. Custom filters on
+ * members_can_user_view_post do not apply here; use members_rest_protected_posts_where.
+ *
  * @since 3.2.23
  * @access public
  * @param string    $where  The WHERE clause of the query.
@@ -584,13 +879,11 @@ function members_filter_protected_posts_for_rest( $posts, $query ) {
  */
 function members_exclude_protected_posts_from_rest_query( $where, $query ) {
 
-	global $wpdb;
-
 	if ( ! members_content_permissions_enabled() || ! members_is_hidden_protected_posts_enabled() ) {
 		return $where;
 	}
 
-	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+	if ( ! members_should_apply_rest_protected_posts_sql( $query ) ) {
 		return $where;
 	}
 
@@ -600,37 +893,27 @@ function members_exclude_protected_posts_from_rest_query( $where, $query ) {
 		return $where;
 	}
 
-	// Posts are restricted via the current '_members_access_role' meta key or the
-	// legacy '_role' key. A user can view a restricted post only when it lists one
-	// of the roles they hold.
-	$roles = is_user_logged_in() ? (array) wp_get_current_user()->roles : array();
+	$user_id = is_user_logged_in() ? get_current_user_id() : 0;
+	$roles   = is_user_logged_in() ? (array) wp_get_current_user()->roles : array();
 
-	if ( empty( $roles ) ) {
+	$where .= members_build_rest_protected_posts_exclusion_sql( $roles, $user_id );
 
-		// No roles means no restriction can be satisfied: exclude every restricted post.
-		$where .= " AND {$wpdb->posts}.ID NOT IN (
-			SELECT post_id FROM {$wpdb->postmeta}
-			WHERE meta_key IN ( '_members_access_role', '_role' )
-		)";
-
-		return $where;
-	}
-
-	// Exclude posts that carry a role restriction none of the current user's roles satisfy.
-	$placeholders = implode( ', ', array_fill( 0, count( $roles ), '%s' ) );
-
-	$where .= $wpdb->prepare(
-		" AND {$wpdb->posts}.ID NOT IN (
-			SELECT restricted.post_id FROM {$wpdb->postmeta} AS restricted
-			WHERE restricted.meta_key IN ( '_members_access_role', '_role' )
-			AND restricted.post_id NOT IN (
-				SELECT allowed.post_id FROM {$wpdb->postmeta} AS allowed
-				WHERE allowed.meta_key IN ( '_members_access_role', '_role' )
-				AND allowed.meta_value IN ( {$placeholders} )
-			)
-		)",
-		$roles
-	);
-
-	return $where;
+	/**
+	 * Filters the SQL WHERE clause used to exclude protected posts from REST collections.
+	 *
+	 * Custom code filtering members_can_user_view_post does not automatically affect
+	 * this SQL exclusion. Use this hook to keep customized permission logic aligned.
+	 *
+	 * @since 3.2.23
+	 *
+	 * @param string   $where  The WHERE clause of the query.
+	 * @param WP_Query $query  The WP_Query object.
+	 */
+	return apply_filters( 'members_rest_protected_posts_where', $where, $query );
 }
+
+# Exclude protected posts from REST API queries at the SQL level so pagination headers stay accurate.
+add_filter( 'posts_where', 'members_exclude_protected_posts_from_rest_query', 10, 2 );
+
+# Filter protected posts from being returned in the REST API.
+add_filter( 'posts_results', 'members_filter_protected_posts_for_rest', 10, 2 );

--- a/inc/functions-content-permissions.php
+++ b/inc/functions-content-permissions.php
@@ -532,6 +532,8 @@ function members_filter_protected_posts_for_rest( $posts, $query ) {
 		return $posts;
 	}
 
+	$removed = 0;
+
 	foreach ( $posts as $key => $post ) {
 		if ( members_can_current_user_view_post( $post->ID ) ) {
 			continue;
@@ -543,7 +545,92 @@ function members_filter_protected_posts_for_rest( $posts, $query ) {
 		}
 
 		unset( $posts[ $key ] );
+		$removed++;
+	}
+
+	// Recompute the query metadata so the REST pagination headers (X-WP-Total /
+	// X-WP-TotalPages) reflect the filtered result set rather than the raw count.
+	// This is a defense-in-depth backstop for any posts not already excluded at
+	// the SQL level by members_exclude_protected_posts_from_rest_query().
+	if ( $removed > 0 && $query instanceof \WP_Query ) {
+
+		$query->found_posts = max( 0, (int) $query->found_posts - $removed );
+
+		$per_page = (int) $query->get( 'posts_per_page' );
+
+		if ( $per_page > 0 ) {
+			$query->max_num_pages = (int) ceil( $query->found_posts / $per_page );
+		}
 	}
 
 	return array_values( $posts );
+}
+
+/**
+ * Excludes protected posts from REST API queries at the SQL level.
+ *
+ * Filtering the results after the query runs (see
+ * members_filter_protected_posts_for_rest()) hides the post bodies but leaves
+ * the row count intact, so the X-WP-Total / X-WP-TotalPages headers and the
+ * per-page "empty array" responses can be used as a side channel to infer the
+ * existence and contents of hidden posts. Excluding the rows in the SQL query
+ * itself keeps the counts accurate and closes that side channel.
+ *
+ * @since 3.2.23
+ * @access public
+ * @param string    $where  The WHERE clause of the query.
+ * @param WP_Query  $query  The WP_Query object.
+ * @return string
+ */
+function members_exclude_protected_posts_from_rest_query( $where, $query ) {
+
+	global $wpdb;
+
+	if ( ! members_content_permissions_enabled() || ! members_is_hidden_protected_posts_enabled() ) {
+		return $where;
+	}
+
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		return $where;
+	}
+
+	// Permission managers may legitimately load protected posts (e.g. the block
+	// editor). They are still filtered per-post by the posts_results filter.
+	if ( current_user_can( 'restrict_content' ) ) {
+		return $where;
+	}
+
+	$roles = array();
+
+	if ( is_user_logged_in() ) {
+		$roles = (array) wp_get_current_user()->roles;
+	}
+
+	if ( empty( $roles ) ) {
+
+		// No roles to satisfy any restriction: exclude every post that carries an
+		// access-role restriction.
+		$where .= " AND {$wpdb->posts}.ID NOT IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_members_access_role' )";
+
+	} else {
+
+		$placeholders = implode( ', ', array_fill( 0, count( $roles ), '%s' ) );
+
+		// Exclude posts that are restricted by at least one role but none of the
+		// roles held by the current user.
+		$subquery = $wpdb->prepare(
+			"SELECT restricted.post_id FROM {$wpdb->postmeta} AS restricted
+				WHERE restricted.meta_key = '_members_access_role'
+				AND restricted.post_id NOT IN (
+					SELECT allowed.post_id FROM {$wpdb->postmeta} AS allowed
+					WHERE allowed.meta_key = '_members_access_role'
+					AND allowed.meta_value IN ( {$placeholders} )
+				)",
+			$roles
+		);
+
+		$where .= " AND {$wpdb->posts}.ID NOT IN ( {$subquery} )";
+	}
+
+	return $where;
 }

--- a/inc/functions-content-permissions.php
+++ b/inc/functions-content-permissions.php
@@ -594,43 +594,43 @@ function members_exclude_protected_posts_from_rest_query( $where, $query ) {
 		return $where;
 	}
 
-	// Permission managers may legitimately load protected posts (e.g. the block
-	// editor). They are still filtered per-post by the posts_results filter.
+	// Permission managers may legitimately load protected posts (e.g. in the block
+	// editor). The posts_results filter still vets each one per-post.
 	if ( current_user_can( 'restrict_content' ) ) {
 		return $where;
 	}
 
-	$roles = array();
-
-	if ( is_user_logged_in() ) {
-		$roles = (array) wp_get_current_user()->roles;
-	}
+	// Posts are restricted via the current '_members_access_role' meta key or the
+	// legacy '_role' key. A user can view a restricted post only when it lists one
+	// of the roles they hold.
+	$roles = is_user_logged_in() ? (array) wp_get_current_user()->roles : array();
 
 	if ( empty( $roles ) ) {
 
-		// No roles to satisfy any restriction: exclude every post that carries an
-		// access-role restriction.
-		$where .= " AND {$wpdb->posts}.ID NOT IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_members_access_role' )";
+		// No roles means no restriction can be satisfied: exclude every restricted post.
+		$where .= " AND {$wpdb->posts}.ID NOT IN (
+			SELECT post_id FROM {$wpdb->postmeta}
+			WHERE meta_key IN ( '_members_access_role', '_role' )
+		)";
 
-	} else {
-
-		$placeholders = implode( ', ', array_fill( 0, count( $roles ), '%s' ) );
-
-		// Exclude posts that are restricted by at least one role but none of the
-		// roles held by the current user.
-		$subquery = $wpdb->prepare(
-			"SELECT restricted.post_id FROM {$wpdb->postmeta} AS restricted
-				WHERE restricted.meta_key = '_members_access_role'
-				AND restricted.post_id NOT IN (
-					SELECT allowed.post_id FROM {$wpdb->postmeta} AS allowed
-					WHERE allowed.meta_key = '_members_access_role'
-					AND allowed.meta_value IN ( {$placeholders} )
-				)",
-			$roles
-		);
-
-		$where .= " AND {$wpdb->posts}.ID NOT IN ( {$subquery} )";
+		return $where;
 	}
+
+	// Exclude posts that carry a role restriction none of the current user's roles satisfy.
+	$placeholders = implode( ', ', array_fill( 0, count( $roles ), '%s' ) );
+
+	$where .= $wpdb->prepare(
+		" AND {$wpdb->posts}.ID NOT IN (
+			SELECT restricted.post_id FROM {$wpdb->postmeta} AS restricted
+			WHERE restricted.meta_key IN ( '_members_access_role', '_role' )
+			AND restricted.post_id NOT IN (
+				SELECT allowed.post_id FROM {$wpdb->postmeta} AS allowed
+				WHERE allowed.meta_key IN ( '_members_access_role', '_role' )
+				AND allowed.meta_value IN ( {$placeholders} )
+			)
+		)",
+		$roles
+	);
 
 	return $where;
 }

--- a/inc/functions-private-site.php
+++ b/inc/functions-private-site.php
@@ -38,14 +38,6 @@ add_filter( 'members_feed_error_message',                              'shortcod
 # Authenticate when accessing the REST API.
 add_filter( 'rest_authentication_errors', 'members_private_rest_api', 95 );
 
-# Exclude protected posts from REST API queries at the SQL level so the result
-# count and pagination headers (X-WP-Total / X-WP-TotalPages) never leak the
-# existence of hidden posts.
-add_filter( 'posts_where', 'members_exclude_protected_posts_from_rest_query', 10, 2 );
-
-# Filter protected posts from being returned in the REST API.
-add_filter( 'posts_results', 'members_filter_protected_posts_for_rest', 10, 2 );
-
 /**
  * Conditional tag to see if we have a private blog.
  *

--- a/inc/functions-private-site.php
+++ b/inc/functions-private-site.php
@@ -38,6 +38,11 @@ add_filter( 'members_feed_error_message',                              'shortcod
 # Authenticate when accessing the REST API.
 add_filter( 'rest_authentication_errors', 'members_private_rest_api', 95 );
 
+# Exclude protected posts from REST API queries at the SQL level so the result
+# count and pagination headers (X-WP-Total / X-WP-TotalPages) never leak the
+# existence of hidden posts.
+add_filter( 'posts_where', 'members_exclude_protected_posts_from_rest_query', 10, 2 );
+
 # Filter protected posts from being returned in the REST API.
 add_filter( 'posts_results', 'members_filter_protected_posts_for_rest', 10, 2 );
 

--- a/members.php
+++ b/members.php
@@ -3,7 +3,7 @@
  * Plugin Name: Members
  * Plugin URI:  https://members-plugin.com/
  * Description: A user and role management plugin that puts you in full control of your site's permissions. This plugin allows you to edit your roles and their capabilities, clone existing roles, assign multiple roles per user, block post content, or even make your site completely private.
- * Version:     3.2.22
+ * Version:     3.2.23
  * Requires PHP: 7.4
  * Author:      MemberPress
  * Author URI:  https://memberpress.com

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: permissions, memberships, roles, capabilities, access
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 3.2.22
+Stable tag: 3.2.23
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -161,6 +161,9 @@ If that doesn't apply or didn't work, stop by our [support forums](https://wordp
 5. Select multiple roles per user (edit user screen)
 
 == Changelog ==
+
+= 3.2.23 =
+* Fixed: Unauthenticated sensitive information disclosure via a REST API pagination side channel (CVE-2026-12426). Protected posts are now excluded from REST queries at the SQL level so the result counts and pagination headers no longer reveal hidden posts.
 
 = 3.2.22 =
 * Added import/export feature


### PR DESCRIPTION
## Summary
Fixes CVE-2026-12426 — Members <= 3.2.22 leaked the existence, exact count, and (via a pagination oracle) keyword content of access-restricted posts to unauthenticated users through the REST API.

The previous `members_filter_protected_posts_for_rest()` filter ran on `posts_results` (after the query) and stripped hidden posts from the response body, but left `$query->found_posts` intact. So `X-WP-Total` / `X-WP-TotalPages` still counted the hidden rows, and per-page empty-array responses worked as a boolean oracle.

## Changes
- **SQL-level exclusion (primary fix):** new `members_exclude_protected_posts_from_rest_query()` on the `posts_where` filter excludes restricted posts from REST queries for non-`restrict_content` users, so the count and pagination headers are accurate and the side channel is gone.
- **Metadata recompute (defense-in-depth):** the existing results filter now recomputes `found_posts` / `max_num_pages` for any posts not caught at the SQL level (e.g. hierarchical/legacy-meta cases).

## Verification (live LocalWP site)
| Scenario | X-WP-Total | Page-2 oracle |
|---|---|---|
| Raw DB search (unfiltered) | 2 | — |
| Anon REST (patched) | 1 | 400, no `[]` |
| Authenticated manager REST | 2 | normal (no regression) |