### PR TITLE
Fix user-edit role checkboxes appearing unresponsive (hidden checkmark) + PHP 8 save hardening (#243)

### DIFF
--- a/admin/class-user-edit.php
+++ b/admin/class-user-edit.php
@@ -98,7 +98,7 @@ final class User_Edit {
 				<th><?php esc_html_e( 'User Roles', 'members' ); ?></th>
 
 				<td>
-					<div class="wp-tab-panel">
+					<div class="wp-tab-panel members-user-roles-panel">
 						<ul>
 						<?php foreach ( $roles as $role ) : ?>
 
@@ -150,8 +150,10 @@ final class User_Edit {
 			// Get the current user roles.
 			$old_roles = (array) $old_user_data->roles;
 
-			// Sanitize the posted roles.
-			$new_roles = array_map( 'members_sanitize_role', $_POST['members_user_roles'] );
+			// Sanitize the posted roles. Using the list sanitizer (rather than a raw array_map
+			// over members_sanitize_role) drops non-string entries, so a crafted nested-array
+			// payload cannot fatal members_sanitize_role() with a TypeError on PHP 8.
+			$new_roles = members_sanitize_access_role_meta_list( wp_unslash( (array) $_POST['members_user_roles'] ) );
 
 			// Loop through the posted roles.
 			foreach ( $new_roles as $new_role ) {
@@ -221,7 +223,40 @@ final class User_Edit {
 	 */
 	public function print_styles() { ?>
 
-		<style type="text/css">.user-role-wrap{ display: none !important; }</style>
+		<style type="text/css">
+			.user-role-wrap{ display: none !important; }
+
+			/*
+			 * Defensive reset for our role checkboxes. Some plugins ship broad admin CSS that
+			 * clobbers core checkbox rendering (e.g. line-height:0), which hides the checkmark
+			 * even though the checkbox still toggles — making it look "unresponsive". Re-assert
+			 * the box model and the checked glyph, scoped to our own panel, so the check shows
+			 * regardless of such global overrides.
+			 */
+			.members-user-roles-panel input[type="checkbox"]{
+				display: inline-block !important;
+				width: 1rem !important;
+				height: 1rem !important;
+				min-width: 1rem !important;
+				min-height: 1rem !important;
+				line-height: normal !important;
+				vertical-align: middle;
+				opacity: 1 !important;
+			}
+			.members-user-roles-panel input[type="checkbox"]:checked::before{
+				display: inline-block !important;
+				float: none !important;
+				width: 1rem !important;
+				height: 1rem !important;
+				margin: -0.1875rem 0 0 -0.25rem !important;
+				line-height: 1 !important;
+			}
+			.members-user-roles-panel label{
+				display: inline-flex;
+				align-items: center;
+				gap: 4px;
+			}
+		</style>
 
 	<?php }
 

--- a/members.php
+++ b/members.php
@@ -3,7 +3,7 @@
  * Plugin Name: Members
  * Plugin URI:  https://members-plugin.com/
  * Description: A user and role management plugin that puts you in full control of your site's permissions. This plugin allows you to edit your roles and their capabilities, clone existing roles, assign multiple roles per user, block post content, or even make your site completely private.
- * Version:     3.2.25
+ * Version:     3.2.26
  * Requires PHP: 7.4
  * Author:      MemberPress
  * Author URI:  https://memberpress.com

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: permissions, memberships, roles, capabilities, access
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 3.2.25
+Stable tag: 3.2.26
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -161,6 +161,10 @@ If that doesn't apply or didn't work, stop by our [support forums](https://wordp
 5. Select multiple roles per user (edit user screen)
 
 == Changelog ==
+
+= 3.2.26 =
+* Fixed: On the user profile / edit-user screen with Multiple User Roles enabled, the role checkboxes could appear to have no checkmark — looking "unresponsive" — when another plugin's admin CSS overrode core checkbox styles (e.g. line-height: 0). The checkboxes always toggled and saved; only the checkmark was hidden. The Members role checkboxes now defensively assert their own rendering so the checkmark shows regardless of such global overrides.
+* Fixed: Hardened the Multiple User Roles save against a possible PHP 8 TypeError from malformed submitted role data (a nested array reaching members_sanitize_role()).
 
 = 3.2.25 =
 * Fixed: Saving a post via the REST API as a user without the `restrict_content` capability (e.g. custom roles, Gutenberg + ACF Pro) failed with "Sorry, you are not allowed to edit the _members_access_role custom field," and silently dropped other meta such as ACF fields. The request pre-processor was hooked to a non-existent action (`rest_before_insert_{$post_type}`) so it never ran; it now correctly strips the Content Permissions meta keys for users who cannot manage them, before the save.


### PR DESCRIPTION
Closes #243

## What users reported
WP.org: "Role checkboxes on user profile pages completely unresponsive." Reporter's environment: WooCommerce, LearnDash, User Registration & Membership (WPEverest), Wordfence; Chrome + Firefox.

## Actual root cause (diagnosed live)
The checkboxes were **not** broken — they toggled and saved correctly. The **User Registration & Membership** plugin ships global admin CSS that overrides core checkbox rendering (`input[type=checkbox] { line-height: 0; display: inline-block; }`), which **collapses the checkmark glyph** (`::before`) so it's invisible. Users saw a box that never appeared to check → "unresponsive." Members rendered bare checkboxes with no defense against such a broad override.

## Fix
1. **Checkmark visibility (defensive CSS).** Scope the role checkboxes with `.members-user-roles-panel` and re-assert their box model + checked glyph in `print_styles()`, so the checkmark renders even when a third-party global style tries to collapse it. Scoped to our own panel — does not touch other admin checkboxes.
2. **PHP 8 save hardening.** `role_update()` now sanitizes posted roles with `members_sanitize_access_role_meta_list()` instead of `array_map( 'members_sanitize_role', $_POST['members_user_roles'] )`. The list sanitizer drops non-string entries, so a crafted nested-array payload can't fatal `members_sanitize_role()` (strtolower on an array) — same class of bug already fixed in the content-permissions meta box.

## Verified live (LocalWP, WP 7.0, headless browser)
- Reproduced the exact conflict (`line-height:0` on all checkboxes). **With the conflict active:** a Members role checkbox renders its checkmark (`::before` line-height restored to 14px, WP checkmark SVG present, box 16×16) while a core checkbox on the same page stays collapsed (`line-height: 0px`) — proving the scoped reset works and is correctly limited to our panel.
- **No conflict:** checkboxes render normally (screenshot), no regression.
- **Functional:** boxes toggle; a real save changed a user from `[subscriber]` → `[subscriber, editor]` with no PHP error.
- **Crash fix:** `members_sanitize_access_role_meta_list(['editor', ['nested'], '', 'subscriber'])` → `["editor","subscriber"]` (no fatal); confirmed the old path's `members_sanitize_role(array)` throws the TypeError it would have fataled on.

Bumped to 3.2.26 + changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
